### PR TITLE
Add model selection and metrics export

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Baseline CTR Model Comparison
 7. DIN (Deep Interest Network)
 8. CTNet (Continual Transfer Network)
 
+示例训练脚本 `experiments/train.py` 提供 `--model` 参数，可直接选择 `DeepFM`、`FFM`、`WideDeep` 或 `DCN` 进行实验。
+
 ## 数据预处理
 - **连续特征缺失**: 统一填充为 0, 并增加二元指示特征。
 - **类别特征缺失**: 填充为特殊字符串 `"unknown"`。
@@ -64,7 +66,8 @@ BenchmarkCTR/
    ```bash
    pip install -r requirements.txt
    ```
-3. 运行示例训练脚本：
+3. 运行示例训练脚本（以 DeepFM 为例）：
    ```bash
-   python experiments/train.py --data data/criteo.csv --epochs 1
+   python experiments/train.py --data data/criteo.csv --epochs 1 \
+       --model DeepFM --output outputs/result.csv
    ```

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -1,14 +1,72 @@
 """Training script skeleton for CTR models using DeepCTR-torch."""
 import argparse
+import os
 import pandas as pd
 import torch
-from deepctr_torch.models import DeepFM
+from deepctr_torch.models import DeepFM, FFM, WideDeep, DCN
 from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
 from deepctr_torch.utils import Dataset
 from torch.utils.data import DataLoader
 from sklearn.metrics import roc_auc_score, log_loss, average_precision_score
 
 from preprocess.utils import preprocess_criteo
+
+
+def get_model(name: str, feature_columns, device):
+    if name.lower() == "deepfm":
+        return DeepFM(
+            linear_feature_columns=feature_columns,
+            dnn_feature_columns=feature_columns,
+            task="binary",
+            dnn_hidden_units=[256, 128, 64],
+            dnn_dropout=0.5,
+            l2_reg_embedding=1e-5,
+            device=device,
+        )
+    if name.lower() == "ffm":
+        return FFM(
+            linear_feature_columns=feature_columns,
+            dnn_feature_columns=feature_columns,
+            task="binary",
+            dnn_hidden_units=[256, 128, 64],
+            device=device,
+        )
+    if name.lower() == "widedeep":
+        return WideDeep(
+            linear_feature_columns=feature_columns,
+            dnn_feature_columns=feature_columns,
+            task="binary",
+            dnn_hidden_units=[256, 128, 64],
+            dnn_dropout=0.5,
+            device=device,
+        )
+    if name.lower() == "dcn":
+        return DCN(
+            linear_feature_columns=feature_columns,
+            dnn_feature_columns=feature_columns,
+            task="binary",
+            dnn_hidden_units=[256, 128, 64],
+            cross_num=2,
+            device=device,
+        )
+    raise ValueError(f"Unknown model: {name}")
+
+
+def evaluate(model, data_loader, device):
+    model.eval()
+    preds, labels = [], []
+    with torch.no_grad():
+        for batch in data_loader:
+            x, y = batch
+            y_pred = model(x)
+            preds.append(y_pred.cpu())
+            labels.append(y)
+    preds = torch.cat(preds).numpy()
+    labels = torch.cat(labels).numpy()
+    auc = roc_auc_score(labels, preds)
+    ll = log_loss(labels, preds)
+    pr_auc = average_precision_score(labels, preds)
+    return auc, ll, pr_auc
 
 
 def main(args: argparse.Namespace) -> None:
@@ -39,18 +97,14 @@ def main(args: argparse.Namespace) -> None:
 
     train_dataset = Dataset(df_train, feature_columns, label_name="click")
     val_dataset = Dataset(df_val, feature_columns, label_name="click")
+    test_dataset = Dataset(df_test, feature_columns, label_name="click")
 
     train_loader = DataLoader(train_dataset, batch_size=1024, shuffle=True, num_workers=0)
     val_loader = DataLoader(val_dataset, batch_size=1024, shuffle=False, num_workers=0)
+    test_loader = DataLoader(test_dataset, batch_size=1024, shuffle=False, num_workers=0)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = DeepFM(linear_feature_columns=feature_columns,
-                   dnn_feature_columns=feature_columns,
-                   task="binary",
-                   dnn_hidden_units=[256, 128, 64],
-                   l2_reg_embedding=1e-5,
-                   dnn_dropout=0.5,
-                   device=device)
+    model = get_model(args.model, feature_columns, device)
     model.to(device)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-5)
@@ -66,24 +120,34 @@ def main(args: argparse.Namespace) -> None:
             loss.backward()
             optimizer.step()
 
-        model.eval()
-        preds, labels = [], []
-        with torch.no_grad():
-            for batch in val_loader:
-                x, y = batch
-                y_pred = model(x)
-                preds.append(y_pred.cpu())
-                labels.append(y)
-        preds = torch.cat(preds).numpy()
-        labels = torch.cat(labels).numpy()
-        auc = roc_auc_score(labels, preds)
-        ll = log_loss(labels, preds)
-        pr_auc = average_precision_score(labels, preds)
-        print(f"Epoch {epoch+1} - AUC {auc:.4f} LogLoss {ll:.4f} PR-AUC {pr_auc:.4f}")
+        val_auc, val_ll, val_pr = evaluate(model, val_loader, device)
+        print(
+            f"Epoch {epoch+1} - AUC {val_auc:.4f} LogLoss {val_ll:.4f} PR-AUC {val_pr:.4f}"
+        )
+
+    test_auc, test_ll, test_pr = evaluate(model, test_loader, device)
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    pd.DataFrame([
+        {
+            "model": args.model,
+            "epochs": args.epochs,
+            "val_auc": val_auc,
+            "val_logloss": val_ll,
+            "val_pr_auc": val_pr,
+            "test_auc": test_auc,
+            "test_logloss": test_ll,
+            "test_pr_auc": test_pr,
+        }
+    ]).to_csv(args.output, index=False)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="CTR model training")
     parser.add_argument("--data", type=str, required=True, help="Path to CSV dataset")
     parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--model", type=str, default="DeepFM", help="Model name: DeepFM/FFM/WideDeep/DCN")
+    parser.add_argument(
+        "--output", type=str, default="outputs/result.csv", help="Path to save metrics CSV"
+    )
     main(parser.parse_args())


### PR DESCRIPTION
## Summary
- support selecting DeepFM, FFM, WideDeep or DCN in `train.py`
- export validation and test metrics to CSV
- document new training script options in README

## Testing
- `python -m py_compile experiments/train.py preprocess/utils.py`
- `python experiments/train.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840a79ff1d48324815e6de9b52e2623