### PR TITLE
Fix optional FFM import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Baseline CTR Model Comparison
 在相同数据集 Criteo Uplift Modeling Dataset 上, 采用统一的预处理与评估流程, 对比以下八种模型的点击率预测性能:
 
 1. FTRL (Follow-The-Regularized-Leader)
-2. FFM (Field-aware Factorization Machine)
+2. FFM (Field-aware Factorization Machine, optional - requires a DeepCTR-Torch
+   version that provides this model)
 3. Wide & Deep
 4. DeepFM
 5. Deep & Cross Network (DCN)
@@ -16,7 +17,7 @@ Baseline CTR Model Comparison
 7. DIN (Deep Interest Network)
 8. CTNet (Continual Transfer Network)
 
-示例训练脚本 `experiments/train.py` 提供 `--model` 参数，可直接选择 `DeepFM`、`FFM`、`WideDeep` 或 `DCN` 进行实验，并支持指定学习率、L2 正则化和 Dropout。
+示例训练脚本 `experiments/train.py` 提供 `--model` 参数，可直接选择 `DeepFM`、`WideDeep` 或 `DCN` 进行实验；若安装了支持 FFM 的 DeepCTR-Torch，也可以选择 `FFM`。脚本支持指定学习率、L2 正则化和 Dropout。
 
 ## 数据预处理
 - **连续特征缺失**: 统一填充为 0, 并增加二元指示特征。

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -5,7 +5,11 @@ import pandas as pd
 import torch
 import time
 from deepctr_torch.inputs import DenseFeat, SparseFeat
-from deepctr_torch.models import DCN, DeepFM, FFM, WideDeep
+from deepctr_torch.models import DCN, DeepFM, WideDeep
+try:
+    from deepctr_torch.models import FFM
+except ImportError:  # pragma: no cover - optional dependency may be missing
+    FFM = None
 from deepctr_torch.utils import Dataset
 from sklearn.metrics import (
     average_precision_score,
@@ -30,6 +34,11 @@ def get_model(name: str, feature_columns, device, dropout: float, l2: float):
             device=device,
         )
     if name.lower() == "ffm":
+        if FFM is None:
+            raise ImportError(
+                "FFM model is not available. Please install a compatible "
+                "version of deepctr-torch that provides FFM."
+            )
         return FFM(
             linear_feature_columns=feature_columns,
             dnn_feature_columns=feature_columns,
@@ -170,7 +179,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="CTR model training")
     parser.add_argument("--data", type=str, required=True, help="Path to CSV dataset")
     parser.add_argument("--epochs", type=int, default=1)
-    parser.add_argument("--model", type=str, default="DeepFM", help="Model name: DeepFM/FFM/WideDeep/DCN")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="DeepFM",
+        help=(
+            "Model name: DeepFM/WideDeep/DCN (FFM if supported by your "
+            "DeepCTR-Torch installation)"
+        ),
+    )
     parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
     parser.add_argument("--l2", type=float, default=1e-5, help="L2 regularization")
     parser.add_argument("--dropout", type=float, default=0.5, help="DNN dropout")


### PR DESCRIPTION
## Summary
- gracefully handle missing `FFM` model in training script
- clarify README that FFM is optional
- update CLI help about model choices

## Testing
- `python -m py_compile experiments/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c52e144c83248a0d749a896ead98