### PR TITLE
Fix preprocessing when feature names lack I/C prefixes

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -118,6 +118,15 @@ def main(args: argparse.Namespace) -> None:
 
     numeric_cols = [c for c in df.columns if c.startswith("I")]
     categorical_cols = [c for c in df.columns if c.startswith("C")]
+    if not numeric_cols and not categorical_cols:
+        exclude_cols = {"click", "label", "treatment", "conversion", "visit"}
+        for col in df.columns:
+            if col.lower() in exclude_cols:
+                continue
+            if pd.api.types.is_numeric_dtype(df[col]):
+                numeric_cols.append(col)
+            else:
+                categorical_cols.append(col)
 
     df_train, scaler, rare_maps = fit_preprocess(df_train, numeric_cols, categorical_cols)
     df_val = apply_preprocess(df_val, numeric_cols, categorical_cols, scaler, rare_maps)

--- a/preprocess/preprocess_criteo.py
+++ b/preprocess/preprocess_criteo.py
@@ -14,6 +14,16 @@ def main(args: argparse.Namespace) -> None:
 
     numeric_cols = [c for c in df.columns if c.startswith("I")]
     categorical_cols = [c for c in df.columns if c.startswith("C")]
+    if not numeric_cols and not categorical_cols:
+        # fallback for datasets without I/C prefixed columns
+        exclude_cols = {"click", "label", "treatment", "conversion", "visit"}
+        for col in df.columns:
+            if col.lower() in exclude_cols:
+                continue
+            if pd.api.types.is_numeric_dtype(df[col]):
+                numeric_cols.append(col)
+            else:
+                categorical_cols.append(col)
 
     df_train, df_val, df_test = split_dataframe(df)
     df_train, scaler, rare_maps = fit_preprocess(df_train, numeric_cols, categorical_cols)

--- a/preprocess/utils.py
+++ b/preprocess/utils.py
@@ -56,8 +56,9 @@ def fit_preprocess(
         df[col] = df[col].where(~df[col].isin(rare_maps[col]), "rare")
 
     scaler = StandardScaler()
-    df[numeric_cols] = scaler.fit_transform(df[numeric_cols])
-
+    if numeric_cols:
+        df[numeric_cols] = scaler.fit_transform(df[numeric_cols])
+    
     return df, scaler, rare_maps
 
 
@@ -74,6 +75,7 @@ def apply_preprocess(
     for col in categorical_cols:
         df[col] = df[col].where(~df[col].isin(rare_maps[col]), "rare")
 
-    df[numeric_cols] = scaler.transform(df[numeric_cols])
+    if numeric_cols:
+        df[numeric_cols] = scaler.transform(df[numeric_cols])
     return df
 


### PR DESCRIPTION
## Summary
- handle datasets without `I*`/`C*` prefixed columns in `preprocess_criteo` and training script
- allow preprocessing utilities to work when there are no numeric features

## Testing
- `python -m preprocess.preprocess_criteo --input dummy.csv --output-dir dummy_out`

------
https://chatgpt.com/codex/tasks/task_e_68420227775083249124b6c13e24d4eb