### PR TITLE
Fix DeepFM training

### DIFF
--- a/models/dataset.py
+++ b/models/dataset.py
@@ -5,12 +5,21 @@ from deepctr_torch.inputs import SparseFeat, DenseFeat
 class CTRDataset(Dataset):
     """Simple Dataset turning dataframe rows into feature dicts for models."""
 
-    def __init__(self, df, feature_columns, label_name="click"):
+    def __init__(self, df, feature_columns, label_name="click", cate_mapping=None):
         self.df = df.reset_index(drop=True)
         self.feature_columns = feature_columns
         self.label = label_name
         self.sparse_cols = [f.name for f in feature_columns if isinstance(f, SparseFeat)]
         self.dense_cols = [f.name for f in feature_columns if isinstance(f, DenseFeat)]
+
+        self.cate_maps = {}
+        for col in self.sparse_cols:
+            if cate_mapping and col in cate_mapping:
+                self.cate_maps[col] = cate_mapping[col]
+            else:
+                cats = self.df[col].astype("category").cat.categories
+                self.cate_maps[col] = {v: i + 1 for i, v in enumerate(cats)}
+            self.df[col] = self.df[col].map(self.cate_maps[col]).fillna(0).astype("int64")
 
     def __len__(self):
         return len(self.df)


### PR DESCRIPTION
## Summary
- encode categorical columns numerically in `CTRDataset`
- make evaluation and training aware of built‑in DeepCTR models
- convert batches to tensor for DeepCTR models
- share category mapping across splits

## Testing
- `python -m py_compile experiments/train.py models/dataset.py`
- `python experiments/train.py --data sample.csv --epochs 1 --model DeepFM --lr 1e-3 --l2 1e-5 --dropout 0.5 --output outputs/result.csv`

------
https://chatgpt.com/codex/tasks/task_e_68424bfaa5a0832481ae2ee80434f69e