### PR TITLE
Add per-epoch metrics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Baseline CTR Model Comparison
 7. DIN (Deep Interest Network)
 8. CTNet (Continual Transfer Network)
 
-示例训练脚本 `experiments/train.py` 提供 `--model` 参数，可直接选择 `DeepFM`、`WideDeep` 或 `DCN` 进行实验；若安装了支持 FFM 的 DeepCTR-Torch，也可以选择 `FFM`。脚本支持指定学习率、L2 正则化和 Dropout。
+示例训练脚本 `experiments/train.py` 提供 `--model` 参数，可直接选择 `DeepFM`、`WideDeep` 或 `DCN` 进行实验；若安装了支持 FFM 的 DeepCTR-Torch，也可以选择 `FFM`。脚本支持指定学习率、L2 正则化和 Dropout，并可通过 `--seed` 设置随机种子以复现结果，训练过程中会在 `--checkpoint-dir` 指定目录下按 epoch 保存模型，并将每个 epoch 的验证指标写入 `--log-file` 指定的 CSV。
 
 ## 数据预处理
 - **连续特征缺失**: 统一填充为 0, 并增加二元指示特征。
@@ -74,7 +74,10 @@ BenchmarkCTR/
    ```
 4. 运行示例训练脚本（以 DeepFM 为例）：
    ```bash
-   python experiments/train.py --data data/criteo.csv --epochs 1 \
-       --model DeepFM --lr 1e-3 --l2 1e-5 --dropout 0.5 \
-       --output outputs/result.csv
-   ```
+    python experiments/train.py --data data/criteo.csv --epochs 1 \
+        --model DeepFM --lr 1e-3 --l2 1e-5 --dropout 0.5 \
+        --output outputs/result.csv \
+        --seed 2025 --checkpoint-dir outputs/checkpoints \
+        --log-file logs/train_metrics.csv
+    ```
+运行多次训练时，指定的 `--output` CSV 会自动追加新行而不会覆盖已有内容。


### PR DESCRIPTION
## Summary
- log validation metrics after each epoch to a CSV file
- append final metrics to result.csv instead of overwriting
- document new `--log-file` option and updated behaviour in README

## Testing
- `python -m py_compile experiments/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6843c22e40f4832481d5ab481546a683