### PR TITLE
Fix FTRL forward when no sparse features

### DIFF
--- a/models/ftrl.py
+++ b/models/ftrl.py
@@ -65,7 +65,14 @@ class FTRLModel(nn.Module):
         self.bias = nn.Parameter(torch.zeros(1))
 
     def forward(self, x):
-        out = self.bias.expand(x[self.sparse_feats[0].name].shape[0], 1)
+        if self.sparse_feats:
+            batch_size = x[self.sparse_feats[0].name].shape[0]
+        elif self.dense_feats:
+            batch_size = x[self.dense_feats[0].name].shape[0]
+        else:
+            raise ValueError("FTRLModel requires at least one feature")
+
+        out = self.bias.expand(batch_size, 1)
         if self.dense_layer is not None:
             dense = torch.cat([x[c.name].float() for c in self.dense_feats], dim=-1)
             out = out + self.dense_layer(dense)


### PR DESCRIPTION
## Summary
- handle dense-only inputs in `FTRLModel.forward`

## Testing
- `pytest -q`
- `python -m py_compile models/ftrl.py`


------
https://chatgpt.com/codex/tasks/task_e_684507da3e98832495f7e26cd0d15493