### PR TITLE
Fix index errors and tidy progress bars

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -7,7 +7,7 @@ import pandas as pd
 import torch
 import time
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from deepctr_torch.inputs import DenseFeat, SparseFeat
@@ -120,7 +120,7 @@ def evaluate(model, data_loader, device, desc: str = "Eval"):
     preds, labels = [], []
     start = time.time()
     with torch.no_grad():
-        for batch in tqdm(data_loader, desc=desc, leave=False):
+        for batch in tqdm(data_loader, desc=desc, leave=False, dynamic_ncols=True, file=sys.stdout):
             x, y = batch
             x = _to_model_input(model, x, device)
             y_pred = model(x)
@@ -231,7 +231,13 @@ def main(args: argparse.Namespace) -> None:
     total_train_time = 0.0
     for epoch in range(args.epochs):
         start_train = time.time()
-        progress = tqdm(train_loader, desc=f"Epoch {epoch+1}/{args.epochs}", unit="batch")
+        progress = tqdm(
+            train_loader,
+            desc=f"Epoch {epoch+1}/{args.epochs}",
+            unit="batch",
+            dynamic_ncols=True,
+            file=sys.stdout,
+        )
         for batch in progress:
             optimizer.zero_grad()
             x, y = batch

--- a/models/ctnet.py
+++ b/models/ctnet.py
@@ -12,7 +12,9 @@ class CTNetModel(nn.Module):
         hidden_units = hidden_units or [256, 128, 64]
         self.sparse_feats = [c for c in feature_columns if isinstance(c, SparseFeat)]
         self.dense_feats = [c for c in feature_columns if isinstance(c, DenseFeat)]
-        embed_dim = self.sparse_feats[0].embedding_dim
+        if not self.sparse_feats and not self.dense_feats:
+            raise ValueError("CTNetModel requires at least one feature")
+        embed_dim = self.sparse_feats[0].embedding_dim if self.sparse_feats else 1
         self.embeddings = nn.ModuleDict(
             {c.name: nn.Embedding(c.vocabulary_size, embed_dim) for c in self.sparse_feats}
         )
@@ -29,9 +31,14 @@ class CTNetModel(nn.Module):
         self.mlp = nn.Sequential(*layers)
 
     def forward(self, x):
-        dense = torch.cat([x[c.name].float() for c in self.dense_feats], dim=-1) if self.dense_feats else None
-        sparse = [self.embeddings[c.name](x[c.name].long()).squeeze(1) for c in self.sparse_feats]
-        concat = torch.cat(([dense] if dense is not None else []) + sparse, dim=-1)
+        dense = (
+            torch.cat([x[c.name].float().unsqueeze(1) for c in self.dense_feats], dim=1)
+            if self.dense_feats
+            else None
+        )
+        sparse = [self.embeddings[c.name](x[c.name].long()) for c in self.sparse_feats]
+        parts = ([] if dense is None else [dense]) + sparse
+        concat = torch.cat(parts, dim=1)
         gated = concat * torch.sigmoid(self.gate(concat))
         out = self.mlp(gated)
         return torch.sigmoid(out.squeeze(-1))


### PR DESCRIPTION
## Summary
- safeguard custom models against missing sparse/dense features
- build dense matrices correctly in FTRL model
- show tqdm progress on stdout with dynamic width to avoid spurious newlines

## Testing
- `python -m py_compile models/*.py experiments/train.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684507da3e98832495f7e26cd0d15493