### PR TITLE
Fix FFM batch preparation

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -42,8 +42,6 @@ def _to_model_input(model, features, device):
     dnn_models = (DeepFM, WDL, DCN)
     if FFM is not None:
         dnn_models = dnn_models + (FFM,)
-    else:
-        dnn_models = dnn_models + (FFMModel,)
 
     if isinstance(model, dnn_models):
         tensors = []


### PR DESCRIPTION
## Summary
- fix `_to_model_input` when using the minimal FFM implementation

## Testing
- `pytest -q`
- `python experiments/train.py --data sample.csv --epochs 1 --model FFM --lr 1e-3 --l2 1e-5 --dropout 0.5 --output outputs/result.csv --seed 2025 --checkpoint-dir outputs/checkpoints --log-file logs/train_metrics.csv`

------
https://chatgpt.com/codex/tasks/task_e_684e375254808324826c3c53af674805