### PR TITLE
Fix FTRL optimizer learning rate

### DIFF
--- a/models/ftrl.py
+++ b/models/ftrl.py
@@ -43,8 +43,9 @@ class FTRLProximal(Optimizer):
                 mask = torch.abs(z) <= l1
                 p.data[mask] = 0.0
                 denom = (beta + n.sqrt()) / alpha + l2
-                p.data[~mask] = - (z[~mask] - torch.sign(z[~mask]) * l1) / denom[~mask]
-                p.data.mul_(lr)
+                p.data[~mask] = -lr * (
+                    z[~mask] - torch.sign(z[~mask]) * l1
+                ) / denom[~mask]
         return loss
 
 


### PR DESCRIPTION
## Summary
- fix learning rate usage in `FTRLProximal` step function

## Testing
- `python -m py_compile models/ftrl.py`

------
https://chatgpt.com/codex/tasks/task_e_684f8251f7c4832495054ac15aaff663