### PR TITLE
Add checkpoint resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,14 @@ BenchmarkCTR/
         --output outputs/result.csv \
         --seed 2025 --checkpoint-dir outputs/checkpoints \
         --log-file logs/train_metrics.csv
-    ```
+   ```
+4. 若需从已有模型继续训练，可传入 `--start-from-checkpoint` 并将 `--epochs`
+   设为额外训练的轮数：
+   ```bash
+    python experiments/train.py --data data/criteo.csv --epochs 2 \
+        --model DeepFM --start-from-checkpoint outputs/checkpoints/DeepFM_epoch_1.pt \
+        --lr 1e-3 --l2 1e-5 --dropout 0.5 \
+        --output outputs/result.csv \
+        --seed 2025 --checkpoint-dir outputs/checkpoints \
+        --log-file logs/train_metrics.csv
+   ```


### PR DESCRIPTION
## Summary
- implement optional checkpoint loading in `train.py`
- save optimizer state when creating checkpoints
- document resume functionality in README

## Testing
- `python -m py_compile experiments/train.py`

------
https://chatgpt.com/codex/tasks/task_e_685387e5a89c8324a1be9cab5f877084