### PR TITLE
Add custom DeepFM implementation

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -11,7 +11,7 @@ from tqdm.auto import tqdm
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from deepctr_torch.inputs import DenseFeat, SparseFeat
-from deepctr_torch.models import DCN, DeepFM, WDL
+from deepctr_torch.models import DCN, WDL
 try:
     from deepctr_torch.models import FFM
 except ImportError:  # pragma: no cover - optional dependency may be missing
@@ -24,6 +24,7 @@ from models import (
     FTRLModel,
     FTRLProximal,
     FFMModel,
+    DeepFMModel,
 )
 from sklearn.metrics import (
     average_precision_score,
@@ -39,7 +40,7 @@ from preprocess.utils import apply_preprocess, fit_preprocess, split_dataframe
 def _to_model_input(model, features, device):
     """Convert a batch from CTRDataset to the format expected by the model."""
 
-    dnn_models = (DeepFM, WDL, DCN)
+    dnn_models = (WDL, DCN)
     if FFM is not None:
         dnn_models = dnn_models + (FFM,)
 
@@ -71,14 +72,11 @@ def get_model(
     embed_dim: int,
 ):
     if name.lower() == "deepfm":
-        return DeepFM(
-            linear_feature_columns=feature_columns,
-            dnn_feature_columns=feature_columns,
-            task="binary",
-            dnn_hidden_units=hidden_units,
-            dnn_dropout=dropout,
-            l2_reg_embedding=l2,
-            device=device,
+        return DeepFMModel(
+            feature_columns,
+            embedding_dim=embed_dim,
+            hidden_units=hidden_units,
+            dropout=dropout,
         )
     if name.lower() == "ffm":
         if FFM is not None:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,6 +3,7 @@ from .ffm import FFMModel
 from .dmr import DMRModel
 from .din import DINModel
 from .ctnet import CTNetModel
+from .deepfm import DeepFMModel
 from .dataset import CTRDataset
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "DMRModel",
     "DINModel",
     "CTNetModel",
+    "DeepFMModel",
     "CTRDataset",
 ]

--- a/models/deepfm.py
+++ b/models/deepfm.py
@@ -1,0 +1,75 @@
+from typing import List
+import torch
+from torch import nn
+from deepctr_torch.inputs import SparseFeat, DenseFeat
+
+
+class DeepFMModel(nn.Module):
+    """Minimal DeepFM implementation honoring feature embedding_dim."""
+
+    def __init__(
+        self,
+        feature_columns: List,
+        embedding_dim: int = 8,
+        hidden_units: List[int] | None = None,
+        dropout: float = 0.5,
+    ):
+        super().__init__()
+        hidden_units = hidden_units or [256, 128, 64]
+        self.sparse_feats = [c for c in feature_columns if isinstance(c, SparseFeat)]
+        self.dense_feats = [c for c in feature_columns if isinstance(c, DenseFeat)]
+        if not self.sparse_feats and not self.dense_feats:
+            raise ValueError("DeepFMModel requires at least one feature")
+        self.embed_dim = embedding_dim
+        self.linear_sparse = nn.ModuleDict(
+            {c.name: nn.Embedding(c.vocabulary_size, 1) for c in self.sparse_feats}
+        )
+        self.linear_dense = nn.ParameterDict(
+            {c.name: nn.Parameter(torch.zeros(1)) for c in self.dense_feats}
+        )
+        self.embeddings = nn.ModuleDict(
+            {c.name: nn.Embedding(c.vocabulary_size, embedding_dim) for c in self.sparse_feats}
+        )
+        self.dense_params = nn.ParameterDict(
+            {c.name: nn.Parameter(torch.zeros(embedding_dim)) for c in self.dense_feats}
+        )
+        for p in self.dense_params.values():
+            nn.init.xavier_uniform_(p.view(1, -1))
+        self.bias = nn.Parameter(torch.zeros(1))
+
+        input_dim = (len(self.sparse_feats) + len(self.dense_feats)) * embedding_dim
+        layers = []
+        prev_dim = input_dim
+        for u in hidden_units:
+            layers.append(nn.Linear(prev_dim, u))
+            layers.append(nn.ReLU())
+            layers.append(nn.Dropout(dropout))
+            prev_dim = u
+        layers.append(nn.Linear(prev_dim, 1))
+        self.dnn = nn.Sequential(*layers)
+
+    def forward(self, x):
+        if self.sparse_feats:
+            batch_size = x[self.sparse_feats[0].name].shape[0]
+        else:
+            batch_size = x[self.dense_feats[0].name].shape[0]
+        out = self.bias.expand(batch_size, 1)
+        for c in self.sparse_feats:
+            out = out + self.linear_sparse[c.name](x[c.name].long())
+        for c in self.dense_feats:
+            out = out + self.linear_dense[c.name] * x[c.name].float().unsqueeze(1)
+
+        embeddings = [self.embeddings[c.name](x[c.name].long()) for c in self.sparse_feats]
+        embeddings += [
+            x[c.name].float().unsqueeze(1) * self.dense_params[c.name]
+            for c in self.dense_feats
+        ]
+        if embeddings:
+            stack = torch.stack(embeddings, dim=1)
+            square_of_sum = torch.sum(stack, dim=1) ** 2
+            sum_of_square = torch.sum(stack ** 2, dim=1)
+            fm_out = 0.5 * torch.sum(square_of_sum - sum_of_square, dim=1, keepdim=True)
+            out = out + fm_out
+            dnn_input = stack.view(batch_size, -1)
+            out = out + self.dnn(dnn_input)
+        return torch.sigmoid(out.squeeze(-1))


### PR DESCRIPTION
## Summary
- implement a minimal DeepFM model using the embedding_dim from feature definitions
- export `DeepFMModel` in `models.__init__`
- update training script to use the custom DeepFM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eed1649948324ade84b8c1e9181dc