### PR TITLE
Remove DeepCTR dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Baseline CTR Model Comparison
 - **数据划分**: 随机打乱后按 70/15/15 划分为训练集、验证集和测试集。
 
 ## 实验实现
-- 框架: Python + PyTorch + DeepCTR
+- 框架: Python + PyTorch
+- Wide & Deep 与 DCN 均由本项目自行实现，无需依赖 DeepCTR
 - 训练参数:
   - `batch_size = 1024`
   - `embedding_dim = 8`

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,7 +4,10 @@ from .dmr import DMRModel
 from .din import DINModel
 from .ctnet import CTNetModel
 from .deepfm import DeepFMModel
+from .widedeep import WideDeepModel
+from .dcn import DCNModel
 from .dataset import CTRDataset
+from .features import SparseFeat, DenseFeat
 
 __all__ = [
     "FTRLModel",
@@ -14,5 +17,9 @@ __all__ = [
     "DINModel",
     "CTNetModel",
     "DeepFMModel",
+    "WideDeepModel",
+    "DCNModel",
     "CTRDataset",
+    "SparseFeat",
+    "DenseFeat",
 ]

--- a/models/ctnet.py
+++ b/models/ctnet.py
@@ -1,7 +1,7 @@
 from typing import List
 import torch
 from torch import nn
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 
 class CTNetModel(nn.Module):
     """Continual Transfer Network with CNN-based feature extractor."""

--- a/models/dataset.py
+++ b/models/dataset.py
@@ -1,6 +1,6 @@
 import torch
 from torch.utils.data import Dataset
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 
 class CTRDataset(Dataset):
     """Simple Dataset turning dataframe rows into feature dicts for models."""

--- a/models/din.py
+++ b/models/din.py
@@ -1,7 +1,7 @@
 from typing import List
 import torch
 from torch import nn
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 
 
 class DINModel(nn.Module):

--- a/models/dmr.py
+++ b/models/dmr.py
@@ -1,7 +1,7 @@
 from typing import List
 import torch
 from torch import nn
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 
 
 class DMRModel(nn.Module):

--- a/models/features.py
+++ b/models/features.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+@dataclass
+class SparseFeat:
+    name: str
+    vocabulary_size: int
+    embedding_dim: int = 1
+
+@dataclass
+class DenseFeat:
+    name: str
+    dimension: int = 1
+

--- a/models/ffm.py
+++ b/models/ffm.py
@@ -2,7 +2,7 @@ import math
 from typing import List
 import torch
 from torch import nn
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 
 
 class FFMModel(nn.Module):

--- a/models/ftrl.py
+++ b/models/ftrl.py
@@ -2,7 +2,7 @@ import math
 from typing import List, Iterable
 import torch
 from torch import nn
-from deepctr_torch.inputs import SparseFeat, DenseFeat
+from .features import SparseFeat, DenseFeat
 from torch.optim.optimizer import Optimizer, required
 
 


### PR DESCRIPTION
## Summary
- remove all `deepctr_torch` imports
- add simple `SparseFeat` and `DenseFeat` dataclasses
- export the feature classes from `models.__init__`
- use the new features in training and models

## Testing
- `python -m py_compile models/*.py experiments/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68648c413ef483249d0953b9a74eb94a