### PR TITLE
Add lazy dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ BenchmarkCTR/
    ```bash
    python experiments/train.py --data data/criteo.csv --epochs 1 --model DeepFM --lr 1e-3 --l2 1e-5 --dropout 0.5 --output outputs/result.csv --seed 2025 --checkpoint-dir outputs/checkpoints --log-file logs/train_metrics.csv --start-from-checkpoint outputs/checkpoints/DeepFM_epoch_2.pt
    ```
-5. FTLR 模型与其他模型略有不同，其使用 `alpha`、`beta`、`l1` 和 `l2` 4个参数。示例训练脚本：
+5. 若内存受限，可事先将训练/验证/测试集分别保存为 CSV，并在训练时启用懒加载：
+   ```bash
+   python experiments/train.py --model DeepFM --train-data train.csv --val-data val.csv --test-data test.csv \
+       --lazy-chunk-size 10000 --epochs 1 --output outputs/result.csv
+   ```
+6. FTLR 模型与其他模型略有不同，其使用 `alpha`、`beta`、`l1` 和 `l2` 4个参数。示例训练脚本：
    ```bash
    python experiments/train.py --data data/criteo.csv --epochs 1 --model FTRL --alpha 0.05 --beta 1.0 --l1 1.0 --l2 1e-5 --output outputs/result.csv --seed 2025 --checkpoint-dir outputs/checkpoints --log-file logs/ftrl_log.csv
    ```

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,7 +6,7 @@ from .ctnet import CTNetModel
 from .deepfm import DeepFMModel
 from .widedeep import WideDeepModel
 from .dcn import DCNModel
-from .dataset import CTRDataset
+from .dataset import CTRDataset, CSVDataset
 from .features import SparseFeat, DenseFeat
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
     "WideDeepModel",
     "DCNModel",
     "CTRDataset",
+    "CSVDataset",
     "SparseFeat",
     "DenseFeat",
 ]


### PR DESCRIPTION
## Summary
- add `CSVDataset` iterable for lazy CSV reading
- support lazy loading via new arguments in `train.py`
- document lazy loading example in README

## Testing
- `python -m compileall -q models experiments preprocess`

------
https://chatgpt.com/codex/tasks/task_e_68649a2ac26c8324ba10f283d32032a4